### PR TITLE
Add a link to build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# worldcubeassociation.org ![Build Status](https://github.com/thewca/worldcubeassociation.org/actions/workflows/ruby.yml/badge.svg?event=push) [![Coverage Status](https://coveralls.io/repos/github/thewca/worldcubeassociation.org/badge.svg?branch=master)](https://coveralls.io/github/thewca/worldcubeassociation.org?branch=master)
+# worldcubeassociation.org [![Build Status](https://github.com/thewca/worldcubeassociation.org/actions/workflows/ruby.yml/badge.svg?event=push)](https://github.com/thewca/worldcubeassociation.org/actions/workflows/ruby.yml) [![Coverage Status](https://coveralls.io/repos/github/thewca/worldcubeassociation.org/badge.svg?branch=master)](https://coveralls.io/github/thewca/worldcubeassociation.org?branch=master)
 
 This repository contains all of the code that runs on [worldcubeassociation.org](https://www.worldcubeassociation.org/).
 


### PR DESCRIPTION
When I click on the build status badge, I want it to display the workflows page.
This PR adds a link to GitHub Actions workflows to the build status badge. 